### PR TITLE
chore: try enable CPUShares , including nix-daemon (doesn't work though)

### DIFF
--- a/hosts/runner/github-runner.nix
+++ b/hosts/runner/github-runner.nix
@@ -64,6 +64,10 @@ in
 
           # lncli just has to touch the real home and won't tolerate `HOME` envvar
           ProtectHome = false;
+
+          # All runners get the same value here, so they all get the same CPU time if needed,
+          # but left-over CPU time can be given to the ones that could use it.
+          CPUShares = 1024;
         };
         extraPackages = [
           # Broken: https://github.com/cachix/cachix-action/issues/179
@@ -75,4 +79,7 @@ in
     })
     runnersNames);
 
+  systemd.services.nix-daemon.serviceConfig = lib.mkForce {
+    CPUShares = 1024;
+  };
 }


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/system/nix-daemon.nix#L195C9-L195C22

Seems like nix somehow completely ignores this setting on nix-daemon.