### PR TITLE
fix: periodically clean up /tmp

### DIFF
--- a/hosts/runner/cleanup.nix
+++ b/hosts/runner/cleanup.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+let
+  timerName = "cleanup-tmp";
+  serviceName = "${timerName}.service";
+in {
+  systemd.services.${serviceName} = {
+    description = "Clean up /tmp files not accessed in the last 24h";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.findutils}/bin/find /tmp -type f -atime +1 -delete";
+      User = "root";
+    };
+    wantedBy = [ "multi-user.target" ];
+  };
+
+  systemd.timers.${timerName} = {
+    description = "Timer for cleaning up /tmp files";
+    partOf = [ serviceName ];
+    wantedBy = [ "timers.target" "multi-user.target" ];
+    timerConfig = {
+      OnCalendar = "daily";
+    };
+  };
+}

--- a/hosts/runner/configuration.nix
+++ b/hosts/runner/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-configuration.nix
     ./disk-config.nix
     ./github-runner.nix
+    ./cleanup.nix
   ];
   boot.loader.grub = {
     # no need to set devices, disko will add all devices that have a EF02 partition to the list already


### PR DESCRIPTION
I haven't deployed yet, but tested the command on runner-03 and it freed up 25% of `/tmp`. Context: I saw some "out of disk space" CI failures today.