### PR TITLE
chore: bump fedimint version to v0.6.2-rc.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -470,16 +470,16 @@
         "nixpkgs-old": "nixpkgs-old"
       },
       "locked": {
-        "lastModified": 1741208322,
-        "narHash": "sha256-wUUzgVlLL9Bh/KsP6Za1x1MxIIk0HzbDTrdmq66wVh0=",
+        "lastModified": 1744066141,
+        "narHash": "sha256-OcQ0ydJLjI41DbiYcFY3HTynE9I+/axO1dYc442OWtU=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "78c57aac027f335e60805c0cbc157f2cff8e6839",
+        "rev": "8c8cbd8b4ae5a7690e4893848584e22c9260edf2",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "v0.6.1-rc.0",
+        "ref": "v0.6.2-rc.1",
         "repo": "fedimint",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     };
 
     fedimint = {
-      url = "github:fedimint/fedimint?ref=v0.6.1-rc.0";
+      url = "github:fedimint/fedimint?ref=v0.6.2-rc.1";
       # inputs.nixpkgs.follows = "nixpkgs";
     };
     fedimint-ui = {


### PR DESCRIPTION
Already deployed to our long-running nix env.