### PR TITLE
chore: reduce ARM builder parallelism

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
             ./disk-config/hetzner-vps.nix
             ./hosts/runner/hardware-configuration-arm.nix
           ] ++ extraModules;
-          runners = ["a" "b"];
+          runners = [ "a" ];
         });
 
       makeFedimintd =


### PR DESCRIPTION
We saw failures in Fedimint likely related to oom killing, so reducing parallelism.