### PR TITLE
chore: remove automatic-timezoned

### DIFF
--- a/hosts/fedimintd/configuration.nix
+++ b/hosts/fedimintd/configuration.nix
@@ -43,7 +43,6 @@
 
   # General server stuff
   boot.tmp.cleanOnBoot = true;
-  services.automatic-timezoned.enable = true;
   nix = {
     # 2.21 seems to break crane vendoring crates
     # package = pkgs.nixVersions.nix_2_21;

--- a/hosts/runner/configuration.nix
+++ b/hosts/runner/configuration.nix
@@ -44,7 +44,6 @@
 
   # General server stuff
   boot.tmp.cleanOnBoot = true;
-  services.automatic-timezoned.enable = true;
   nix = {
     # 2.21 seems to break crane vendoring crates
     # package = pkgs.nixVersions.nix_2_21;


### PR DESCRIPTION
The `automatic-timezoned` service keeps failing on redeploys, something about dbus, doesn't feel worth debugging given that we probably want UTC on all our systems anyway.

```
× automatic-timezoned.service - Automatically update system timezone based on location
     Loaded: loaded (/etc/systemd/system/automatic-timezoned.service; enabled; preset: ignored)
     Active: failed (Result: exit-code) since Thu 2025-06-05 14:22:55 UTC; 5s ago
   Duration: 309ms
 Invocation: 8bd6a388ef23411d8964b4e40f9c4303
    Process: 1582571 ExecStart=/nix/store/hmb1lsixfvj2xkm0mp93ji2msif57kxx-automatic-timezoned-2.0.73/bin/automatic-timezoned (code=exited, status=1/FAILURE)
   Main PID: 1582571 (code=exited, status=1/FAILURE)
         IP: 0B in, 0B out
         IO: 0B read, 0B written
   Mem peak: 41.8M
        CPU: 84ms

Jun 05 14:22:55 runner-01 systemd[1]: Starting Automatically update system timezone based on location...
Jun 05 14:22:55 runner-01 systemd[1]: Started Automatically update system timezone based on location.
Jun 05 14:22:55 runner-01 automatic-timezoned[1582571]: [INFO  automatic_timezoned] Starting automatic-timezoned 2.0.73...
Jun 05 14:22:55 runner-01 automatic-timezoned[1582571]: Error: MethodError(OwnedErrorName("org.freedesktop.DBus.Error.AccessDenied"), Some("Permission denied"), Msg { type: Error, serial: 5, sender: UniqueName(":1.4662"), reply-serial: 13, body: Str, fds: [] })
Jun 05 14:22:55 runner-01 systemd[1]: automatic-timezoned.service: Main process exited, code=exited, status=1/FAILURE
Jun 05 14:22:55 runner-01 systemd[1]: automatic-timezoned.service: Failed with result 'exit-code'.
```