### PR TITLE
chore: share assumeutxo snapshot using torrent on our runners

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,8 @@
           perfit = inputs.perfit.packages.${final.system}.perfit;
           fedimint-cli = fedimint.packages.${final.system}.fedimint-cli;
           fedimintd = fedimint.packages.${final.system}.fedimintd;
+          # we need yet unreleased 0.9.0 version of rqbit for `rqbit share`
+          rqbit = final.callPackage ./nix/pkgs/rqbit.nix {};
         })
       ];
 
@@ -100,6 +102,7 @@
             ./disk-config/hetzner-ax162.nix
             ./hosts/runner/hardware-configuration-amd.nix
             ./hosts/runner/check-temp.nix
+            ./modules/seed-assumeutxo.nix
           ] ++ extraModules;
           runners = ["a" "b" "c" "d"];
         });

--- a/modules/seed-assumeutxo.nix
+++ b/modules/seed-assumeutxo.nix
@@ -1,0 +1,70 @@
+{ pkgs, ... }:
+let
+  rqbitScript = ''
+    set -e
+
+    UTXO_FILE="/var/lib/rqbit-assumeutxo/utxo-840000.dat"
+    EXPECTED_CHECKSUM="dc4bb43d58d6a25e91eae93eb052d72e3318bd98ec62a5d0c11817cefbba177b"
+    MAGNET_URL="magnet:?xt=urn:btih:596c26cc709e213fdfec997183ff67067241440c&dn=utxo-840000.dat&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969"
+
+    cd /var/lib/rqbit-assumeutxo
+
+    if [[ -f "$UTXO_FILE" ]]; then
+      CURRENT_CHECKSUM=$(sha256sum "$UTXO_FILE" | cut -d' ' -f1)
+      if [[ "$CURRENT_CHECKSUM" == "$EXPECTED_CHECKSUM" ]]; then
+        echo "File exists with correct checksum, sharing..."
+        exec ${pkgs.rqbit}/bin/rqbit share utxo-840000.dat
+      else
+        echo "File exists but checksum is incorrect, removing and downloading..."
+        rm -f "$UTXO_FILE"
+      fi
+    fi
+
+    if [[ ! -f "$UTXO_FILE" ]]; then
+      echo "File does not exist, downloading..."
+      ${pkgs.rqbit}/bin/rqbit download "$MAGNET_URL"
+      
+      if [[ -f "$UTXO_FILE" ]]; then
+        CURRENT_CHECKSUM=$(sha256sum "$UTXO_FILE" | cut -d' ' -f1)
+        if [[ "$CURRENT_CHECKSUM" == "$EXPECTED_CHECKSUM" ]]; then
+          echo "Downloaded file has correct checksum, sharing..."
+          exec ${pkgs.rqbit}/bin/rqbit share utxo-840000.dat
+        else
+          echo "Downloaded file has incorrect checksum!"
+          exit 1
+        fi
+      else
+        echo "Download failed!"
+        exit 1
+      fi
+    fi
+  '';
+in
+{
+  systemd.services.rqbit-assumeutxo = {
+    description = "Share utxo-840000.dat over BitTorrent";
+    after = [ "network.target" ];
+    wantedBy = [ "multi-user.target" ];
+
+    serviceConfig = {
+      Type = "exec";
+      ExecStart = pkgs.writeShellScript "rqbit-assumeutxo-script" rqbitScript;
+      WorkingDirectory = "/var/lib/rqbit-assumeutxo";
+      StateDirectory = "rqbit-assumeutxo";
+      User = "rqbit-assumeutxo";
+      Group = "rqbit-assumeutxo";
+      Restart = "on-failure";
+      RestartSec = "30s";
+    };
+  };
+
+  users.users.rqbit-assumeutxo = {
+    isSystemUser = true;
+    group = "rqbit-assumeutxo";
+    home = "/var/lib/rqbit-assumeutxo";
+    createHome = true;
+  };
+
+  users.groups.rqbit-assumeutxo = { };
+
+}

--- a/nix/pkgs/rqbit.nix
+++ b/nix/pkgs/rqbit.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  buildNpmPackage,
+  nodejs_20,
+  nix-update-script,
+}:
+let
+  pname = "rqbit";
+
+  version = "9.0.0";
+
+  src = fetchFromGitHub {
+    owner = "ikatson";
+    repo = "rqbit";
+    rev = "2d5db26a2a55740c6dfd7565894148ddbd1a04a1";
+    hash = "sha256-+dj/ResAFOoMJJ1qVLicKo9uNIeHBOPy0Z/1aWn501M=";
+  };
+
+  rqbit-webui = buildNpmPackage {
+    pname = "rqbit-webui";
+
+    nodejs = nodejs_20;
+
+    inherit version src;
+
+    sourceRoot = "${src.name}/crates/librqbit/webui";
+
+    npmDepsHash = "sha256-tqfRuG27f5u30ghK8kjluCnDOjgJ4xy7aZkj6dLwQWA=";
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/dist
+      cp -r dist/** $out/dist
+
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  inherit pname version src;
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-LNlXicXXouqtepkrYqlavrNY7YjXyZhRq9yOTaebFfI=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
+
+  preConfigure = ''
+    mkdir -p crates/librqbit/webui/dist
+    cp -R ${rqbit-webui}/dist/** crates/librqbit/webui/dist
+  '';
+
+  postPatch = ''
+    # This script fascilitates the build of the webui,
+    #  we've already built that
+    rm crates/librqbit/build.rs
+  '';
+
+  doCheck = false;
+
+  passthru.webui = rqbit-webui;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "webui"
+    ];
+  };
+
+  meta = {
+    description = "Bittorrent client in Rust";
+    homepage = "https://github.com/ikatson/rqbit";
+    changelog = "https://github.com/ikatson/rqbit/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      cafkafk
+      toasteruwu
+    ];
+    mainProgram = "rqbit";
+  };
+}
+


### PR DESCRIPTION
This share the exact same file described in:

https://blog.lopp.net/bitcoin-node-sync-with-utxo-snapshots/

Making it good enough (IMO) to rely on in our docker compose scripts etc. in the future to speed up bitcoind initialization. It also makes our runners do some side pro bono work.

You can try downloading the file using Bitcoin Torrent client and


```
magnet:?xt=urn:btih:596c26cc709e213fdfec997183ff67067241440c
```

link.
