### PR TITLE
feat: write out nixpkgs timestamp in /etc/nixpkgs-last-modified

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
           inherit system;
           modules = [
             topLevelModule
+            ./modules/nixos-nixpkgs-last-modified.nix
 
             disko.nixosModules.disko
             agenix.nixosModules.default
@@ -127,7 +128,7 @@
 
           modules = [
             topLevelModule
-
+            ./modules/nixos-nixpkgs-last-modified.nix
 
             disko.nixosModules.disko
             agenix.nixosModules.default
@@ -152,6 +153,7 @@
           system = "x86_64-linux";
           modules = [
             topLevelModule
+            ./modules/nixos-nixpkgs-last-modified.nix
 
             disko.nixosModules.disko
             agenix.nixosModules.default
@@ -171,6 +173,7 @@
           system = "x86_64-linux";
           modules = [
             topLevelModule
+            ./modules/nixos-nixpkgs-last-modified.nix
 
             disko.nixosModules.disko
             agenix.nixosModules.default

--- a/modules/nixos-nixpkgs-last-modified.nix
+++ b/modules/nixos-nixpkgs-last-modified.nix
@@ -1,0 +1,3 @@
+{ inputs, ... }: {
+  environment.etc."nixpkgs-last-modified".text = toString inputs.nixpkgs.lastModified;
+}


### PR DESCRIPTION
This will allow us to check periodically (in the CI) if the system is up to date enough, and remind us to update github runners from time to time, before github runner is out of date and stops running.