### PR TITLE
chore(runners): update self-hosted runners

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -856,11 +856,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1777428379,
-        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
         "type": "github"
       },
       "original": {

--- a/hosts/runner/github-runner.nix
+++ b/hosts/runner/github-runner.nix
@@ -35,7 +35,10 @@ in
     extraGroups = [ "docker" ];
   };
 
-  virtualisation.docker.enable = true;
+  virtualisation.docker = {
+    enable = true;
+    package = pkgs.docker_29;
+  };
 
   services.github-runners = lib.listToAttrs (map
     (name: {
@@ -90,7 +93,7 @@ in
         };
         extraPackages = with pkgs; [
           gawk
-          docker
+          docker_29
           cachix
           gnupg
           curl


### PR DESCRIPTION
## Summary

Update the self-hosted GitHub runner flake inputs and pin runner Docker usage to Docker 29.

## Deployment

Applied successfully to:

- runner-01
- runner-02
- runner-04
- runner-arm-01

Notes: runner-02 was applied twice; the second run was idempotent and successful.