### PR TITLE
fix(runners): jitter cleanup timers

### DIFF
--- a/hosts/runner/cleanup.nix
+++ b/hosts/runner/cleanup.nix
@@ -27,7 +27,8 @@ in
     description = "Timer for cleaning up /tmp files";
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "hourly";
+      OnCalendar = "*-*-* *:05:00";
+      RandomizedDelaySec = "30min";
     };
   };
 
@@ -50,7 +51,8 @@ in
     description = "Timer for cleaning up /tmp files";
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "daily";
+      OnCalendar = "*-*-* 02:17:00";
+      RandomizedDelaySec = "3h";
     };
   };
 
@@ -73,7 +75,8 @@ in
     description = "Timer for gc the /nix store";
     wantedBy = [ "timers.target" ];
     timerConfig = {
-      OnCalendar = "daily";
+      OnCalendar = "*-*-* 03:23:00";
+      RandomizedDelaySec = "8h";
     };
   };
 }


### PR DESCRIPTION
### Summary

Schedule runner cleanup timers away from exact hour boundaries and add randomized delays so cleanup work is staggered across hosts. This especially spreads out the nix store GC job, reducing the odds that all runners contend with active builds at the same time.

### Verification

- `nix eval .#nixosConfigurations.runner-01.config.systemd.timers --apply 'timers: builtins.mapAttrs (_: timer: timer.timerConfig) { cleanup-tmp = timers.cleanup-tmp; cleanup-docker = timers.cleanup-docker; gc-nix = timers.gc-nix; }' --json`