### PR TITLE
chore(nix): update nixpkgs to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -344,9 +344,7 @@
         "fenix": "fenix_2",
         "flake-utils": "flake-utils_5",
         "flakebox": "flakebox_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-unstable": "nixpkgs-unstable"
       },
       "locked": {
@@ -698,7 +696,7 @@
         "crane": "crane_3",
         "fenix": "fenix_3",
         "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "systems": "systems_14"
       },
       "locked": {
@@ -856,21 +854,37 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1781509190,
-        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
-        "owner": "NixOS",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "owner": "nixos",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1711124224,
         "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
@@ -886,7 +900,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1711124224,
         "narHash": "sha256-l0zlN/3CiodvWDtfBOVxeTwYSRz93muVbXWSpaMjXxM=",
@@ -906,7 +920,7 @@
       "inputs": {
         "flake-utils": "flake-utils_9",
         "flakebox": "flakebox_3",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1717900416,
@@ -929,7 +943,7 @@
         "disko": "disko",
         "fedimint": "fedimint",
         "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "perfit": "perfit"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     flake-utils.url = "github:numtide/flake-utils";
 
@@ -18,7 +18,6 @@
     fedimint = {
       # url = "github:fedimint/fedimint?ref=v0.7.1";
       url = "github:fedimint/fedimint?rev=de7448559f5ddcff63698d624d6592156870a533";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 

--- a/modules/radicle.nix
+++ b/modules/radicle.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }: {
+{ lib, pkgs, ... }: {
 
   age.secrets = {
     radicle-seednode = {
@@ -10,11 +10,9 @@
     };
   };
 
-
   services.radicle = {
     enable = true;
-    privateKeyFile = "/run/secrets/radicle/seednode";
-    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYKej/5RMfmhoyaOqHr/AZmhxrQGYBIm/U4dnfrLHSd dpc@ren";
+    publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYKej/5RMfmhoyaOqHr/AZmhxrQGYBIm/U4dnfrLHSd";
     node.openFirewall = true;
     node.listenAddress = "[::0]";
     settings = {
@@ -34,6 +32,10 @@
     httpd.nginx.forceSSL = true;
   };
 
+  systemd.services.radicle-node.serviceConfig = {
+    ImportCredential = lib.mkForce [ ];
+    LoadCredential = [ "dev.radicle.node.secret:/run/secrets/radicle/seednode" ];
+  };
 
   environment.systemPackages = with pkgs; [
     perfit

--- a/nix/pkgs/rqbit.nix
+++ b/nix/pkgs/rqbit.nix
@@ -6,7 +6,7 @@
   pkg-config,
   openssl,
   buildNpmPackage,
-  nodejs_20,
+  nodejs,
   nix-update-script,
 }:
 let
@@ -24,7 +24,7 @@ let
   rqbit-webui = buildNpmPackage {
     pname = "rqbit-webui";
 
-    nodejs = nodejs_20;
+    inherit nodejs;
 
     inherit version src;
 
@@ -85,4 +85,3 @@ rustPlatform.buildRustPackage {
     mainProgram = "rqbit";
   };
 }
-


### PR DESCRIPTION
### Summary

Update the primary nixpkgs input from `nixos-25.11` to `nixos-26.05` and keep all host configurations building.

### Notes

- Kept the pinned fedimint input on its own nixpkgs because that older fedimint revision still depends on `clang14`, which is removed from nixpkgs 26.05.
- Updated Radicle secret wiring for the new NixOS Radicle module options.
- Updated the custom `rqbit` package away from insecure EOL `nodejs_20` and removed now-default `useFetchCargoVendor`.

### Verification

Built all host toplevels with `nix build -L`:

- `fedimintd-01`
- `fedimintd-02`
- `fedimintd-03`
- `fedimintd-04`
- `irohdns-eu-01`
- `irohdns-us-01`
- `irohrelay-eu-01`
- `irohrelay-us-01`
- `runner-01`
- `runner-02`
- `runner-04`
- `runner-arm-01`